### PR TITLE
fixes to compile xc_utils on Debian Stretch 

### DIFF
--- a/src/loadCombinations/actions/Action.h
+++ b/src/loadCombinations/actions/Action.h
@@ -25,6 +25,7 @@
 #define ACTION_H
 
 #include <string>
+#include <vector>
 #include <deque>
 #include <cmath>
 #include "xc_utils/src/kernel/NamedEntity.h"


### PR DESCRIPTION
to compile xc_utils on Debian Stretch I had to add include of vector header on one place

bernd